### PR TITLE
Add mocked pipeline test and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -q
+python_files = test_*.py
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,67 @@
+import sys
+import yaml
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pipeline_orchestrator as po
+from subtitle_extractor.get_subtitles import YouTubeSubtitlesExtractor
+
+
+def test_run_full_pipeline(tmp_path, monkeypatch):
+    # Prepare temporary configuration
+    config = {
+        "logging": {"level": "INFO", "log_file": str(tmp_path / "test.log")},
+        "pipeline": {
+            "subtitles": {"output_dir": str(tmp_path / "subs"), "language": "ru"},
+            "text_processing": {"output_dir": str(tmp_path / "processed")},
+            "results_dir": str(tmp_path / "processed"),
+        },
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config, allow_unicode=True))
+
+    # Mock environment for OpenAI (not used but required by original class)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    class DummyProcessor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def process_subtitles_file(self, transcript_path, output_dir):
+            output_dir = Path(output_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            json_path = output_dir / f"{transcript_path.stem}_out.json"
+            md_path = output_dir / f"{transcript_path.stem}_out.md"
+            json_path.write_text("{}", encoding="utf-8")
+            md_path.write_text("# md", encoding="utf-8")
+            return {
+                "json_output": str(json_path),
+                "md_output": str(md_path),
+                "blocks_created": 1,
+            }
+
+    monkeypatch.setattr(po, "SarsekenovProcessor", DummyProcessor)
+
+    orchestrator = po.PipelineOrchestrator(str(config_path))
+
+    # Mock YouTube subtitles retrieval
+    dummy_subtitles = [{"text": "hello", "start": 0, "duration": 1}]
+    monkeypatch.setattr(
+        YouTubeSubtitlesExtractor,
+        "get_subtitles",
+        lambda self, video_id, language="ru": dummy_subtitles,
+    )
+
+    result = orchestrator.run_full_pipeline("https://youtu.be/dQw4w9WgXcQ")
+
+    assert result["status"] == "success"
+
+    subs_stage = result["stages"]["subtitles"]
+    assert Path(subs_stage["json_path"]).is_file()
+    assert Path(subs_stage["srt_path"]).is_file()
+    assert Path(subs_stage["txt_path"]).is_file()
+
+    final = result["final_outputs"]
+    assert Path(final["sag_v2_json"]).is_file()
+    assert Path(final["review_markdown"]).is_file()


### PR DESCRIPTION
## Summary
- configure pytest and add mocked pipeline test
- mock YouTube and OpenAI interactions to validate run_full_pipeline outputs
- add GitHub Actions workflow running `pytest -q`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d394e970832480499627dff76720