### PR TITLE
Add YouTube channel transcript downloader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and insert your YouTube Data API v3 key.
+YOUTUBE_API_KEY=your_youtube_data_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ tmp/
 # data/pipeline_results/
 data/chromadb/
 data/video_registry.json
+data/transcript_registry.json
+transcript_output/
 
 # ========================================
 # СИСТЕМНЫЕ ФАЙЛЫ
@@ -106,4 +108,4 @@ node_modules/
 
 # Task files
 # tasks.json
-# tasks/ 
+# tasks/

--- a/YOUTUBE_TRANSCRIPTS_GUIDE.md
+++ b/YOUTUBE_TRANSCRIPTS_GUIDE.md
@@ -1,0 +1,63 @@
+# Загрузчик русских субтитров YouTube
+
+Автономный CLI-модуль получает список роликов канала через официальный YouTube Data API v3, фильтрует ролики по включительному диапазону дат и сохраняет доступные русские субтитры в структурированные TXT-файлы.
+
+Старый `pipeline_orchestrator.py`, SAG/RAG, ChromaDB и обработчики текста не используются.
+
+## Установка
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements-transcripts.txt
+```
+
+Добавьте ключ в существующий `.env`:
+
+```dotenv
+YOUTUBE_API_KEY=AIza...
+```
+
+## Проверка без скачивания
+
+```powershell
+python run_channel_transcripts.py --from-date 2025-01-01 --to-date 2025-01-31 --dry-run --verbose
+```
+
+## Скачивание
+
+```powershell
+python run_channel_transcripts.py --from-date 2025-01-01 --to-date 2025-12-31
+```
+
+Канал по умолчанию — `@Salsar`. Другой handle можно передать через `--channel`.
+
+## Полезные параметры
+
+```text
+--output PATH       папка TXT, по умолчанию transcript_output
+--registry PATH     JSON-реестр, по умолчанию data/transcript_registry.json
+--limit N           обработать максимум N роликов
+--force             перезаписать уже обработанные ролики
+--retry-skipped     повторить ролики без русских субтитров
+--retry-failed      повторить failed и unavailable
+--dry-run           только показать найденные ролики
+--verbose           подробный лог
+```
+
+## Результат
+
+```text
+transcript_output/YYYY/MM/YYYY-MM-DD_Название_VIDEOID.txt
+```
+
+В каждом TXT сохраняются название, дата публикации, ссылка, ID ролика, тип русских субтитров и полный очищенный текст без таймкодов.
+
+Состояние записывается после каждого ролика в `data/transcript_registry.json`, поэтому обработка продолжается после остановки.
+
+## Тесты
+
+```powershell
+python -m pytest tests/youtube_channel_transcripts -v
+```
+
+`youtube-transcript-api` использует недокументированный веб-интерфейс YouTube. При блокировке IP программа запишет ошибку в реестр и продолжит пакетную обработку.

--- a/requirements-transcripts.txt
+++ b/requirements-transcripts.txt
@@ -1,0 +1,4 @@
+google-api-python-client>=2.0,<3
+python-dotenv>=1.0,<2
+youtube-transcript-api>=1.2.4,<2
+pytest>=8.0,<10

--- a/run_channel_transcripts.py
+++ b/run_channel_transcripts.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Run the isolated YouTube channel transcript downloader from repository root."""
+
+from youtube_channel_transcripts.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/youtube_channel_transcripts/test_dates.py
+++ b/tests/youtube_channel_transcripts/test_dates.py
@@ -1,0 +1,63 @@
+from datetime import date
+
+import pytest
+
+from youtube_channel_transcripts.cli import CLIArgumentError, build_parser, validate_args
+from youtube_channel_transcripts.youtube_client import YouTubeChannelClient
+
+
+class Request:
+    def __init__(self, response):
+        self.response = response
+
+    def execute(self):
+        return self.response
+
+
+class PlaylistItems:
+    def __init__(self, response):
+        self.response = response
+
+    def list(self, **kwargs):
+        return Request(self.response)
+
+
+class Service:
+    def __init__(self, response):
+        self.response = response
+
+    def playlistItems(self):
+        return PlaylistItems(self.response)
+
+
+def test_inclusive_date_boundaries():
+    response = {
+        "items": [
+            {
+                "snippet": {"title": "Start"},
+                "contentDetails": {
+                    "videoId": "aaaaaaaaaaa",
+                    "videoPublishedAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            {
+                "snippet": {"title": "End"},
+                "contentDetails": {
+                    "videoId": "bbbbbbbbbbb",
+                    "videoPublishedAt": "2025-01-31T23:59:59Z",
+                },
+            },
+        ]
+    }
+    client = YouTubeChannelClient("test", service=Service(response))
+    videos = list(client.iter_videos("uploads", date(2025, 1, 1), date(2025, 1, 31)))
+    assert [video.title for video in videos] == ["Start", "End"]
+
+
+def test_from_date_after_to_date_is_rejected():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["--from-date", "2025-02-01", "--to-date", "2025-01-01"]
+    )
+    with pytest.raises(CLIArgumentError):
+        validate_args(args)

--- a/tests/youtube_channel_transcripts/test_registry.py
+++ b/tests/youtube_channel_transcripts/test_registry.py
@@ -1,0 +1,40 @@
+import json
+from datetime import datetime, timezone
+
+from youtube_channel_transcripts.models import VideoItem
+from youtube_channel_transcripts.registry import TranscriptRegistry
+
+
+def make_video():
+    return VideoItem(
+        video_id="abcdefghijk",
+        title="Видео",
+        published_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        url="https://www.youtube.com/watch?v=abcdefghijk",
+    )
+
+
+def test_processed_video_is_skipped_on_next_run(tmp_path):
+    path = tmp_path / "registry.json"
+    registry = TranscriptRegistry(path)
+    registry.update(make_video(), status="processed", output_file="out.txt")
+
+    reloaded = TranscriptRegistry(path)
+    assert reloaded.should_process("abcdefghijk") is False
+    assert reloaded.should_process("abcdefghijk", force=True) is True
+
+
+def test_stale_processing_record_is_retried(tmp_path):
+    registry = TranscriptRegistry(tmp_path / "registry.json")
+    registry.update(make_video(), status="processing")
+    assert registry.should_process("abcdefghijk") is True
+
+
+def test_registry_is_valid_json_and_leaves_no_temp_files(tmp_path):
+    path = tmp_path / "registry.json"
+    registry = TranscriptRegistry(path)
+    registry.update(make_video(), status="failed", error="test")
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["videos"]["abcdefghijk"]["status"] == "failed"
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/youtube_channel_transcripts/test_storage.py
+++ b/tests/youtube_channel_transcripts/test_storage.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from youtube_channel_transcripts.models import TranscriptResult, VideoItem
+from youtube_channel_transcripts.storage import build_output_path, safe_filename_component, save_transcript
+
+
+def make_video(title="Bad: title? <test>"):
+    return VideoItem(
+        video_id="abcdefghijk",
+        title=title,
+        published_at=datetime(2025, 6, 15, tzinfo=timezone.utc),
+        url="https://www.youtube.com/watch?v=abcdefghijk",
+    )
+
+
+def test_windows_safe_filename_preserves_video_id():
+    path = build_output_path(Path("out"), make_video())
+    assert path.name.endswith("_abcdefghijk.txt")
+    assert not any(char in path.name for char in '<>:"/\\|?*')
+
+
+def test_reserved_windows_name_is_prefixed():
+    assert safe_filename_component("CON") == "_CON"
+
+
+def test_save_transcript_writes_structured_utf8_txt(tmp_path):
+    video = make_video("Название")
+    transcript = TranscriptResult(("текст",), "автоматические")
+    path = save_transcript(tmp_path, video, transcript, "Полный текст")
+    content = path.read_text(encoding="utf-8")
+    assert "Название: Название" in content
+    assert "Дата публикации: 15.06.2025" in content
+    assert "Тип субтитров: автоматические" in content
+    assert content.rstrip().endswith("Полный текст")

--- a/tests/youtube_channel_transcripts/test_text_cleaner.py
+++ b/tests/youtube_channel_transcripts/test_text_cleaner.py
@@ -1,0 +1,18 @@
+from youtube_channel_transcripts.text_cleaner import clean_transcript
+
+
+def test_clean_transcript_removes_noise_and_html_entities():
+    result = clean_transcript(
+        ["Привет&nbsp;мир", "[Музыка]", "<i>Это тест</i>", "  ещё   текст  "]
+    )
+    assert result == "Привет мир Это тест ещё текст"
+
+
+def test_clean_transcript_removes_rolling_overlap():
+    result = clean_transcript(["это начало", "это начало фразы", "фразы и продолжение"])
+    assert result == "это начало фразы и продолжение"
+
+
+def test_content_brackets_inside_sentence_are_preserved():
+    result = clean_transcript(["Используйте параметр [режим 2] в настройках"])
+    assert result == "Используйте параметр [режим 2] в настройках"

--- a/tests/youtube_channel_transcripts/test_transcript_service.py
+++ b/tests/youtube_channel_transcripts/test_transcript_service.py
@@ -1,0 +1,127 @@
+import sys
+import types
+
+import pytest
+
+from youtube_channel_transcripts.transcript_service import RussianTranscriptService
+
+
+class CouldNotRetrieveTranscript(Exception):
+    pass
+
+
+class NoTranscriptFound(CouldNotRetrieveTranscript):
+    pass
+
+
+class AgeRestricted(CouldNotRetrieveTranscript):
+    pass
+
+
+class InvalidVideoId(CouldNotRetrieveTranscript):
+    pass
+
+
+class IpBlocked(CouldNotRetrieveTranscript):
+    pass
+
+
+class PoTokenRequired(CouldNotRetrieveTranscript):
+    pass
+
+
+class RequestBlocked(CouldNotRetrieveTranscript):
+    pass
+
+
+class TranscriptsDisabled(CouldNotRetrieveTranscript):
+    pass
+
+
+class VideoUnavailable(CouldNotRetrieveTranscript):
+    pass
+
+
+class VideoUnplayable(CouldNotRetrieveTranscript):
+    pass
+
+
+class YouTubeRequestFailed(CouldNotRetrieveTranscript):
+    pass
+
+
+class FakeYouTubeTranscriptApi:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def fake_youtube_transcript_modules(monkeypatch):
+    package = types.ModuleType("youtube_transcript_api")
+    package.YouTubeTranscriptApi = FakeYouTubeTranscriptApi
+    errors = types.ModuleType("youtube_transcript_api._errors")
+    for cls in [
+        AgeRestricted,
+        CouldNotRetrieveTranscript,
+        InvalidVideoId,
+        IpBlocked,
+        NoTranscriptFound,
+        PoTokenRequired,
+        RequestBlocked,
+        TranscriptsDisabled,
+        VideoUnavailable,
+        VideoUnplayable,
+        YouTubeRequestFailed,
+    ]:
+        setattr(errors, cls.__name__, cls)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", package)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api._errors", errors)
+
+
+class Track:
+    def __init__(self, generated, text):
+        self.is_generated = generated
+        self.language_code = "ru"
+        self._text = text
+
+    def fetch(self):
+        return [{"text": self._text}]
+
+
+class ListWithManual:
+    def find_manually_created_transcript(self, languages):
+        assert languages == ["ru"]
+        return Track(False, "ручной текст")
+
+    def find_generated_transcript(self, languages):
+        raise AssertionError("generated track must not be requested")
+
+
+class ListWithGeneratedOnly:
+    def find_manually_created_transcript(self, languages):
+        raise NoTranscriptFound()
+
+    def find_generated_transcript(self, languages):
+        return Track(True, "автоматический текст")
+
+
+class Api:
+    def __init__(self, transcript_list):
+        self.transcript_list = transcript_list
+
+    def list(self, video_id):
+        assert video_id == "abcdefghijk"
+        return self.transcript_list
+
+
+def test_manual_russian_track_has_priority():
+    service = RussianTranscriptService(api=Api(ListWithManual()), sleep=lambda _: None)
+    result = service.fetch("abcdefghijk")
+    assert result.subtitle_type == "ручные"
+    assert result.snippets == ("ручной текст",)
+
+
+def test_generated_russian_track_is_fallback():
+    service = RussianTranscriptService(api=Api(ListWithGeneratedOnly()), sleep=lambda _: None)
+    result = service.fetch("abcdefghijk")
+    assert result.subtitle_type == "автоматические"
+    assert result.snippets == ("автоматический текст",)

--- a/tests/youtube_channel_transcripts/test_youtube_client.py
+++ b/tests/youtube_channel_transcripts/test_youtube_client.py
@@ -1,0 +1,34 @@
+from youtube_channel_transcripts.youtube_client import YouTubeChannelClient
+
+
+class Request:
+    def __init__(self, response):
+        self.response = response
+
+    def execute(self):
+        return self.response
+
+
+class Channels:
+    def list(self, **kwargs):
+        assert kwargs["forHandle"] == "@Salsar"
+        return Request(
+            {
+                "items": [
+                    {
+                        "snippet": {"title": "Salsar"},
+                        "contentDetails": {"relatedPlaylists": {"uploads": "UU123"}},
+                    }
+                ]
+            }
+        )
+
+
+class Service:
+    def channels(self):
+        return Channels()
+
+
+def test_resolve_uploads_playlist_uses_handle_without_network():
+    client = YouTubeChannelClient("test", service=Service())
+    assert client.resolve_uploads_playlist("Salsar") == ("UU123", "Salsar")

--- a/youtube_channel_transcripts/__init__.py
+++ b/youtube_channel_transcripts/__init__.py
@@ -1,0 +1,5 @@
+"""CLI package for downloading Russian YouTube transcripts by date range."""
+
+from .models import TranscriptResult, VideoItem
+
+__all__ = ["TranscriptResult", "VideoItem"]

--- a/youtube_channel_transcripts/cli.py
+++ b/youtube_channel_transcripts/cli.py
@@ -1,0 +1,212 @@
+"""Command-line interface for channel transcript downloading."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import Sequence
+
+from dotenv import load_dotenv
+
+from .models import RunStats
+from .registry import RegistryError, TranscriptRegistry
+from .storage import save_transcript
+from .text_cleaner import clean_transcript
+from .transcript_service import (
+    RussianTranscriptNotFound,
+    RussianTranscriptService,
+    TranscriptServiceError,
+    TranscriptTemporaryError,
+    TranscriptUnavailable,
+)
+from .youtube_client import YouTubeChannelClient, YouTubeClientError
+
+
+class CLIArgumentError(ValueError):
+    """Raised instead of terminating inside argparse."""
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise CLIArgumentError(message)
+
+
+def parse_date(value: str) -> date:
+    """Parse ``YYYY-MM-DD`` for argparse."""
+
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected YYYY-MM-DD") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = ArgumentParser(
+        description="Download Russian subtitles from a YouTube channel by inclusive date range."
+    )
+    parser.add_argument("--from-date", required=True, type=parse_date, help="Start date YYYY-MM-DD")
+    parser.add_argument("--to-date", required=True, type=parse_date, help="End date YYYY-MM-DD")
+    parser.add_argument("--channel", default="@Salsar", help="YouTube channel handle")
+    parser.add_argument("--output", type=Path, default=Path("transcript_output"))
+    parser.add_argument(
+        "--registry", type=Path, default=Path("data/transcript_registry.json")
+    )
+    parser.add_argument("--force", action="store_true", help="Reprocess every matching video")
+    parser.add_argument(
+        "--retry-skipped",
+        action="store_true",
+        help="Retry videos previously skipped without Russian subtitles",
+    )
+    parser.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Retry failed and unavailable videos",
+    )
+    parser.add_argument("--limit", type=int, help="Process at most N matching videos")
+    parser.add_argument("--dry-run", action="store_true", help="List videos without writing files")
+    parser.add_argument("--verbose", action="store_true", help="Enable detailed logging")
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.from_date > args.to_date:
+        raise CLIArgumentError("--from-date cannot be later than --to-date")
+    if args.limit is not None and args.limit < 1:
+        raise CLIArgumentError("--limit must be at least 1")
+
+
+def _print_stats(stats: RunStats) -> None:
+    print("\nИтоги:")
+    print(f"Найдено видео: {stats.found}")
+    print(f"Сохранено: {stats.saved}")
+    print(f"Без русских субтитров: {stats.no_russian}")
+    print(f"Уже обработано: {stats.already_processed}")
+    print(f"Недоступно: {stats.unavailable}")
+    print(f"Ошибок: {stats.failed}")
+
+
+def _short_error(exc: BaseException, limit: int = 240) -> str:
+    value = " ".join(str(exc).split())
+    return value[:limit] + ("…" if len(value) > limit else "")
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute one CLI run. Per-video failures do not abort the batch."""
+
+    load_dotenv()
+    api_key = os.getenv("YOUTUBE_API_KEY", "").strip()
+    if not api_key:
+        print("[ERROR] YOUTUBE_API_KEY is missing in .env or environment", file=sys.stderr)
+        return 1
+
+    try:
+        client = YouTubeChannelClient(api_key)
+        playlist_id, channel_title = client.resolve_uploads_playlist(args.channel)
+        videos = list(client.iter_videos(playlist_id, args.from_date, args.to_date))
+    except (YouTubeClientError, ValueError) as exc:
+        print(f"[ERROR] {_short_error(exc)}", file=sys.stderr)
+        return 1
+
+    if args.limit is not None:
+        videos = videos[: args.limit]
+
+    print(f"Канал: {channel_title} ({YouTubeChannelClient.normalize_handle(args.channel)})")
+    print(f"Диапазон: {args.from_date.isoformat()} — {args.to_date.isoformat()} включительно")
+    print(f"Найдено: {len(videos)}")
+
+    if args.dry_run:
+        for index, video in enumerate(videos, 1):
+            print(f"[{index}/{len(videos)}] {video.published_date} — {video.title}")
+        print("\n[DRY-RUN] Субтитры не запрашивались, файлы и реестр не изменялись.")
+        return 0
+
+    try:
+        registry = TranscriptRegistry(args.registry)
+        transcript_service = RussianTranscriptService()
+    except (RegistryError, TranscriptServiceError, ValueError) as exc:
+        print(f"[ERROR] {_short_error(exc)}", file=sys.stderr)
+        return 1
+
+    stats = RunStats(found=len(videos))
+    output_root: Path = args.output
+
+    for index, video in enumerate(videos, 1):
+        print(f"\n[{index}/{len(videos)}] {video.published_date} — {video.title}")
+        if not registry.should_process(
+            video.video_id,
+            force=args.force,
+            retry_skipped=args.retry_skipped,
+            retry_failed=args.retry_failed,
+        ):
+            stats.already_processed += 1
+            print("[SKIP] Уже обработано или исключено реестром")
+            continue
+
+        try:
+            registry.update(video, status="processing")
+            transcript = transcript_service.fetch(video.video_id)
+            text = clean_transcript(transcript.snippets)
+            if not text:
+                raise TranscriptServiceError("Transcript is empty after cleanup")
+            output_path = save_transcript(output_root, video, transcript, text)
+            registry.update(
+                video,
+                status="processed",
+                subtitle_type=transcript.subtitle_type,
+                output_file=str(output_path),
+            )
+            stats.saved += 1
+            print(f"[OK] Сохранено: {output_path}")
+        except RussianTranscriptNotFound as exc:
+            registry.update(
+                video,
+                status="skipped_no_russian_subtitles",
+                error=_short_error(exc),
+            )
+            stats.no_russian += 1
+            print("[SKIP] Русские субтитры отсутствуют")
+        except TranscriptUnavailable as exc:
+            registry.update(video, status="unavailable", error=_short_error(exc))
+            stats.unavailable += 1
+            print(f"[SKIP] Видео или субтитры недоступны: {_short_error(exc)}")
+        except (TranscriptTemporaryError, TranscriptServiceError, OSError) as exc:
+            try:
+                registry.update(video, status="failed", error=_short_error(exc))
+            except RegistryError as registry_exc:
+                print(f"[ERROR] Реестр недоступен: {_short_error(registry_exc)}", file=sys.stderr)
+                return 1
+            stats.failed += 1
+            print(f"[ERROR] {_short_error(exc)}")
+        except RegistryError as exc:
+            print(f"[ERROR] Реестр недоступен: {_short_error(exc)}", file=sys.stderr)
+            return 1
+        except KeyboardInterrupt:
+            print("\n[STOP] Остановлено пользователем. Следующий запуск продолжит обработку.")
+            _print_stats(stats)
+            return 130
+
+    _print_stats(stats)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point returning a process exit code."""
+
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        validate_args(args)
+    except CLIArgumentError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        parser.print_usage(sys.stderr)
+        return 2
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    return run(args)

--- a/youtube_channel_transcripts/models.py
+++ b/youtube_channel_transcripts/models.py
@@ -1,0 +1,56 @@
+"""Data models used by the transcript downloader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class VideoItem:
+    """A public video discovered in a channel uploads playlist."""
+
+    video_id: str
+    title: str
+    published_at: datetime
+    url: str
+
+    @property
+    def published_date(self) -> str:
+        """Return the publication date in ISO ``YYYY-MM-DD`` format."""
+
+        return self.published_at.date().isoformat()
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptResult:
+    """A fetched transcript and its metadata."""
+
+    snippets: tuple[str, ...]
+    subtitle_type: str
+    language_code: str = "ru"
+
+
+@dataclass(slots=True)
+class RunStats:
+    """Counters shown at the end of a CLI run."""
+
+    found: int = 0
+    saved: int = 0
+    no_russian: int = 0
+    already_processed: int = 0
+    unavailable: int = 0
+    failed: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return counters as a serializable mapping."""
+
+        return {
+            "found": self.found,
+            "saved": self.saved,
+            "no_russian": self.no_russian,
+            "already_processed": self.already_processed,
+            "unavailable": self.unavailable,
+            "failed": self.failed,
+        }

--- a/youtube_channel_transcripts/registry.py
+++ b/youtube_channel_transcripts/registry.py
@@ -1,0 +1,121 @@
+"""Crash-safe JSON registry for resumable transcript downloads."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .models import VideoItem
+
+
+class RegistryError(RuntimeError):
+    """Raised when a registry cannot be read or written safely."""
+
+
+class TranscriptRegistry:
+    """Persist per-video processing status after each video."""
+
+    VERSION = "1.0"
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.data = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"version": self.VERSION, "updated_at": None, "videos": {}}
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RegistryError(f"Cannot read registry {self.path}: {exc}") from exc
+
+        if not isinstance(data, dict) or not isinstance(data.get("videos"), dict):
+            raise RegistryError(f"Invalid registry structure: {self.path}")
+        data.setdefault("version", self.VERSION)
+        data.setdefault("updated_at", None)
+        return data
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def get(self, video_id: str) -> dict[str, Any] | None:
+        """Return a video record when present."""
+
+        record = self.data["videos"].get(video_id)
+        return record if isinstance(record, dict) else None
+
+    def should_process(
+        self,
+        video_id: str,
+        *,
+        force: bool = False,
+        retry_skipped: bool = False,
+        retry_failed: bool = False,
+    ) -> bool:
+        """Decide whether a video should run during the current invocation."""
+
+        if force:
+            return True
+        record = self.get(video_id)
+        if not record:
+            return True
+
+        status = record.get("status")
+        if status == "processed":
+            return False
+        if status == "skipped_no_russian_subtitles":
+            return retry_skipped
+        if status in {"failed", "unavailable"}:
+            return retry_failed
+        return True  # includes stale ``processing`` records
+
+    def update(
+        self,
+        video: VideoItem,
+        *,
+        status: str,
+        subtitle_type: str | None = None,
+        output_file: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Update a video record and atomically persist the registry."""
+
+        self.data["videos"][video.video_id] = {
+            "video_id": video.video_id,
+            "title": video.title,
+            "published_date": video.published_date,
+            "url": video.url,
+            "status": status,
+            "subtitle_type": subtitle_type,
+            "output_file": output_file,
+            "processed_at": self._now(),
+            "error": error,
+        }
+        self.save()
+
+    def save(self) -> None:
+        """Write the registry atomically through a same-directory temporary file."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.data["updated_at"] = self._now()
+        payload = json.dumps(self.data, ensure_ascii=False, indent=2) + "\n"
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=self.path.parent
+        )
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+        except OSError as exc:
+            raise RegistryError(f"Cannot save registry {self.path}: {exc}") from exc
+        finally:
+            temporary.unlink(missing_ok=True)

--- a/youtube_channel_transcripts/storage.py
+++ b/youtube_channel_transcripts/storage.py
@@ -1,0 +1,92 @@
+"""TXT output and Windows-safe file naming."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from .models import TranscriptResult, VideoItem
+
+_INVALID_WINDOWS_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1F]')
+_SPACE_RE = re.compile(r"\s+")
+_RESERVED_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def safe_filename_component(value: str, max_length: int = 120) -> str:
+    """Return a Windows-safe filename component."""
+
+    cleaned = _INVALID_WINDOWS_CHARS.sub("_", value)
+    cleaned = _SPACE_RE.sub(" ", cleaned).strip(" .")
+    if not cleaned:
+        cleaned = "video"
+    if cleaned.upper() in _RESERVED_NAMES:
+        cleaned = f"_{cleaned}"
+    return cleaned[:max_length].rstrip(" .") or "video"
+
+
+def build_output_path(output_root: Path, video: VideoItem, max_filename: int = 190) -> Path:
+    """Build ``output/YYYY/MM/YYYY-MM-DD_title_videoid.txt``."""
+
+    date_text = video.published_date
+    prefix = f"{date_text}_"
+    suffix = f"_{video.video_id}.txt"
+    allowed_title = max(20, max_filename - len(prefix) - len(suffix))
+    title = safe_filename_component(video.title, allowed_title)
+    filename = f"{prefix}{title}{suffix}"
+    return output_root / f"{video.published_at.year:04d}" / f"{video.published_at.month:02d}" / filename
+
+
+def format_txt(video: VideoItem, transcript: TranscriptResult, text: str) -> str:
+    """Create the required structured UTF-8 TXT content."""
+
+    date_text = video.published_at.strftime("%d.%m.%Y")
+    return (
+        f"Название: {video.title}\n"
+        f"Дата публикации: {date_text}\n"
+        f"Ссылка: {video.url}\n"
+        f"ID ролика: {video.video_id}\n"
+        "Язык субтитров: русский\n"
+        f"Тип субтитров: {transcript.subtitle_type}\n\n"
+        "============================================================\n\n"
+        f"{text.strip()}\n"
+    )
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically replace a UTF-8 text file in its destination directory."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def save_transcript(
+    output_root: Path,
+    video: VideoItem,
+    transcript: TranscriptResult,
+    text: str,
+) -> Path:
+    """Save one transcript and return its path."""
+
+    path = build_output_path(output_root, video)
+    atomic_write_text(path, format_txt(video, transcript, text))
+    return path

--- a/youtube_channel_transcripts/text_cleaner.py
+++ b/youtube_channel_transcripts/text_cleaner.py
@@ -1,0 +1,80 @@
+"""Conservative cleanup for subtitle fragments."""
+
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Iterable
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_SPACE_RE = re.compile(r"\s+")
+_STAGE_RE = re.compile(
+    r"^\s*[\[(](?:музыка|аплодисменты|смех|шум|тишина|music|applause|laughter)[\])]\s*[.!…]*\s*$",
+    re.IGNORECASE,
+)
+_NOTE_RE = re.compile(r"^\s*[♪♫]+\s*$")
+
+
+def clean_fragment(value: str) -> str:
+    """Normalize one subtitle fragment without rewriting its content."""
+
+    text = html.unescape(str(value))
+    text = _TAG_RE.sub(" ", text)
+    text = text.replace("\u200b", " ").replace("\ufeff", " ")
+    text = _SPACE_RE.sub(" ", text).strip()
+    if not text or _STAGE_RE.fullmatch(text) or _NOTE_RE.fullmatch(text):
+        return ""
+    return text
+
+
+def _normalized_tokens(text: str) -> list[str]:
+    return text.casefold().split()
+
+
+def _append_without_overlap(parts: list[str], current: str, max_overlap: int = 20) -> None:
+    """Append a caption while removing exact rolling-caption overlap."""
+
+    if not parts:
+        parts.append(current)
+        return
+
+    previous = parts[-1]
+    prev_norm = previous.casefold()
+    current_norm = current.casefold()
+
+    if current_norm == prev_norm or prev_norm.startswith(current_norm):
+        return
+    if current_norm.startswith(prev_norm + " "):
+        remainder = current[len(previous) :].strip()
+        if remainder:
+            parts.append(remainder)
+        return
+
+    prev_tokens = _normalized_tokens(previous)
+    current_tokens = current.split()
+    current_norm_tokens = [token.casefold() for token in current_tokens]
+    limit = min(len(prev_tokens), len(current_norm_tokens), max_overlap)
+
+    overlap = 0
+    for size in range(limit, 1, -1):
+        if prev_tokens[-size:] == current_norm_tokens[:size]:
+            overlap = size
+            break
+
+    if overlap:
+        remainder = " ".join(current_tokens[overlap:]).strip()
+        if remainder:
+            parts.append(remainder)
+    else:
+        parts.append(current)
+
+
+def clean_transcript(fragments: Iterable[str]) -> str:
+    """Combine subtitle fragments into one cleaned text without timestamps."""
+
+    parts: list[str] = []
+    for fragment in fragments:
+        cleaned = clean_fragment(fragment)
+        if cleaned:
+            _append_without_overlap(parts, cleaned)
+    return _SPACE_RE.sub(" ", " ".join(parts)).strip()

--- a/youtube_channel_transcripts/transcript_service.py
+++ b/youtube_channel_transcripts/transcript_service.py
@@ -1,0 +1,159 @@
+"""Russian transcript retrieval using youtube-transcript-api."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .models import TranscriptResult
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TranscriptServiceError(RuntimeError):
+    """Base error for transcript retrieval."""
+
+
+class RussianTranscriptNotFound(TranscriptServiceError):
+    """Raised when neither manual nor generated Russian subtitles exist."""
+
+
+class TranscriptUnavailable(TranscriptServiceError):
+    """Raised when the video or its transcript endpoint is unavailable."""
+
+
+class TranscriptTemporaryError(TranscriptServiceError):
+    """Raised after retryable transcript failures are exhausted."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ExceptionTypes:
+    no_transcript: tuple[type[BaseException], ...]
+    unavailable: tuple[type[BaseException], ...]
+    retryable: tuple[type[BaseException], ...]
+    api_base: tuple[type[BaseException], ...]
+
+
+class RussianTranscriptService:
+    """Fetch manual Russian subtitles first, then generated Russian subtitles."""
+
+    def __init__(
+        self,
+        api: Any | None = None,
+        retries: int = 3,
+        retry_delay: float = 1.5,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if retries < 1:
+            raise ValueError("retries must be at least 1")
+        if retry_delay < 0:
+            raise ValueError("retry_delay cannot be negative")
+
+        self.retries = retries
+        self.retry_delay = retry_delay
+        self._sleep = sleep
+
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+            from youtube_transcript_api._errors import (
+                AgeRestricted,
+                CouldNotRetrieveTranscript,
+                InvalidVideoId,
+                IpBlocked,
+                NoTranscriptFound,
+                PoTokenRequired,
+                RequestBlocked,
+                TranscriptsDisabled,
+                VideoUnavailable,
+                VideoUnplayable,
+                YouTubeRequestFailed,
+            )
+        except ImportError as exc:  # pragma: no cover - environment validation
+            raise TranscriptServiceError(
+                "youtube-transcript-api is not installed. "
+                "Run: python -m pip install -r requirements-transcripts.txt"
+            ) from exc
+
+        self._api = api or YouTubeTranscriptApi()
+        self._exceptions = _ExceptionTypes(
+            no_transcript=(NoTranscriptFound,),
+            unavailable=(
+                AgeRestricted,
+                InvalidVideoId,
+                PoTokenRequired,
+                TranscriptsDisabled,
+                VideoUnavailable,
+                VideoUnplayable,
+            ),
+            retryable=(YouTubeRequestFailed, RequestBlocked, IpBlocked),
+            api_base=(CouldNotRetrieveTranscript,),
+        )
+
+    def fetch(self, video_id: str) -> TranscriptResult:
+        """Fetch Russian subtitles without using automatic translation."""
+
+        last_retryable: BaseException | None = None
+        for attempt in range(1, self.retries + 1):
+            try:
+                transcript_list = self._api.list(video_id)
+                transcript = self._find_russian_track(transcript_list)
+                fetched = transcript.fetch()
+                snippets = tuple(
+                    text
+                    for text in (self._snippet_text(item) for item in fetched)
+                    if text
+                )
+                return TranscriptResult(
+                    snippets=snippets,
+                    subtitle_type="автоматические" if transcript.is_generated else "ручные",
+                    language_code=transcript.language_code,
+                )
+            except RussianTranscriptNotFound:
+                raise
+            except self._exceptions.no_transcript as exc:
+                raise RussianTranscriptNotFound(str(exc)) from exc
+            except self._exceptions.unavailable as exc:
+                raise TranscriptUnavailable(str(exc)) from exc
+            except self._exceptions.retryable as exc:
+                last_retryable = exc
+                if attempt < self.retries:
+                    delay = self.retry_delay * attempt
+                    LOGGER.warning(
+                        "Temporary transcript error for %s (attempt %s/%s): %s",
+                        video_id,
+                        attempt,
+                        self.retries,
+                        exc.__class__.__name__,
+                    )
+                    self._sleep(delay)
+                    continue
+                break
+            except self._exceptions.api_base as exc:
+                raise TranscriptServiceError(str(exc)) from exc
+            except Exception as exc:
+                raise TranscriptServiceError(
+                    f"Unexpected transcript error for {video_id}: {exc}"
+                ) from exc
+
+        raise TranscriptTemporaryError(str(last_retryable) if last_retryable else "Unknown error")
+
+    @staticmethod
+    def _snippet_text(item: Any) -> str:
+        if hasattr(item, "text"):
+            return str(item.text)
+        if isinstance(item, dict):
+            return str(item.get("text", ""))
+        return str(item)
+
+    def _find_russian_track(self, transcript_list: Any) -> Any:
+        try:
+            return transcript_list.find_manually_created_transcript(["ru"])
+        except self._exceptions.no_transcript:
+            pass
+
+        try:
+            return transcript_list.find_generated_transcript(["ru"])
+        except self._exceptions.no_transcript as exc:
+            raise RussianTranscriptNotFound("Russian subtitles are not available") from exc

--- a/youtube_channel_transcripts/youtube_client.py
+++ b/youtube_channel_transcripts/youtube_client.py
@@ -1,0 +1,154 @@
+"""Official YouTube Data API client for enumerating channel uploads."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+from typing import Any, Iterator
+
+from .models import VideoItem
+
+LOGGER = logging.getLogger(__name__)
+
+
+class YouTubeClientError(RuntimeError):
+    """Raised when the channel or its uploads cannot be read."""
+
+
+class YouTubeChannelClient:
+    """Read videos from a channel uploads playlist via YouTube Data API v3."""
+
+    def __init__(self, api_key: str, service: Any | None = None) -> None:
+        if not api_key and service is None:
+            raise ValueError("YouTube API key is required")
+
+        if service is not None:
+            self._youtube = service
+            return
+
+        try:
+            from googleapiclient.discovery import build
+        except ImportError as exc:  # pragma: no cover - environment validation
+            raise YouTubeClientError(
+                "google-api-python-client is not installed. "
+                "Run: python -m pip install -r requirements-transcripts.txt"
+            ) from exc
+
+        self._youtube = build("youtube", "v3", developerKey=api_key, cache_discovery=False)
+
+    @staticmethod
+    def normalize_handle(handle: str) -> str:
+        """Normalize a channel handle for ``channels.list(forHandle=...)``."""
+
+        value = handle.strip()
+        if not value:
+            raise ValueError("Channel handle cannot be empty")
+        return value if value.startswith("@") else f"@{value}"
+
+    @staticmethod
+    def parse_rfc3339(value: str) -> datetime:
+        """Parse a YouTube RFC3339 timestamp into an aware UTC datetime."""
+
+        normalized = value.strip().replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def resolve_uploads_playlist(self, handle: str) -> tuple[str, str]:
+        """Return ``(uploads_playlist_id, channel_title)`` for a handle."""
+
+        normalized = self.normalize_handle(handle)
+        try:
+            response = (
+                self._youtube.channels()
+                .list(part="snippet,contentDetails", forHandle=normalized, maxResults=1)
+                .execute()
+            )
+        except Exception as exc:  # google client exposes several transport errors
+            raise YouTubeClientError(f"YouTube API channel request failed: {exc}") from exc
+
+        items = response.get("items", [])
+        if not items:
+            raise YouTubeClientError(f"Channel not found for handle {normalized}")
+
+        item = items[0]
+        try:
+            playlist_id = item["contentDetails"]["relatedPlaylists"]["uploads"]
+        except (KeyError, TypeError) as exc:
+            raise YouTubeClientError("Channel uploads playlist is missing in API response") from exc
+
+        title = item.get("snippet", {}).get("title") or normalized
+        return playlist_id, title
+
+    def iter_videos(
+        self,
+        uploads_playlist_id: str,
+        from_date: date,
+        to_date: date,
+    ) -> Iterator[VideoItem]:
+        """Yield public videos whose publication dates are inside the inclusive range."""
+
+        if from_date > to_date:
+            raise ValueError("from_date cannot be later than to_date")
+
+        page_token: str | None = None
+        reached_older_items = False
+
+        while True:
+            try:
+                response = (
+                    self._youtube.playlistItems()
+                    .list(
+                        part="snippet,contentDetails",
+                        playlistId=uploads_playlist_id,
+                        maxResults=50,
+                        pageToken=page_token,
+                    )
+                    .execute()
+                )
+            except Exception as exc:
+                raise YouTubeClientError(f"YouTube API playlist request failed: {exc}") from exc
+
+            for item in response.get("items", []):
+                snippet = item.get("snippet") or {}
+                content = item.get("contentDetails") or {}
+                video_id = content.get("videoId") or (
+                    snippet.get("resourceId") or {}
+                ).get("videoId")
+                title = (snippet.get("title") or "").strip()
+                published_raw = content.get("videoPublishedAt") or snippet.get("publishedAt")
+
+                if not video_id or not published_raw:
+                    LOGGER.debug("Skipping playlist item without video id or date")
+                    continue
+                if title.casefold() in {"private video", "deleted video"}:
+                    LOGGER.debug("Skipping inaccessible video %s", video_id)
+                    continue
+
+                try:
+                    published_at = self.parse_rfc3339(published_raw)
+                except (TypeError, ValueError):
+                    LOGGER.warning("Skipping %s: invalid publication date %r", video_id, published_raw)
+                    continue
+
+                published_day = published_at.date()
+                if published_day > to_date:
+                    continue
+                if published_day < from_date:
+                    reached_older_items = True
+                    continue
+
+                yield VideoItem(
+                    video_id=video_id,
+                    title=title or f"Video {video_id}",
+                    published_at=published_at,
+                    url=f"https://www.youtube.com/watch?v={video_id}",
+                )
+
+            if reached_older_items:
+                break
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break


### PR DESCRIPTION
## Что сделано

Добавлен автономный CLI-модуль для скачивания русских субтитров с YouTube-канала за включительный диапазон дат.

- канал по умолчанию `@Salsar`;
- официальный YouTube Data API v3 для канала, uploads-плейлиста, названий и дат;
- ручные русские субтитры имеют приоритет, затем автоматические русские;
- ролики без русских субтитров пропускаются;
- структурированные UTF-8 TXT без таймкодов;
- папки `transcript_output/YYYY/MM`;
- атомарный JSON-реестр для продолжения после остановки;
- режимы `--force`, `--retry-skipped`, `--retry-failed`, `--dry-run`, `--limit`, `--verbose`;
- отдельный минимальный файл зависимостей и инструкция для Windows/PowerShell;
- существующие SAG/RAG, ChromaDB и `pipeline_orchestrator.py` не изменены.

## Проверка

Локально в изолированной среде выполнено:

```text
python -m compileall -q .
python -m pytest tests/youtube_channel_transcripts -v
```

Результат: `14 passed`.

## Что проверить в IDE

1. Установить `requirements-transcripts.txt`.
2. Убедиться, что в `.env` задан `YOUTUBE_API_KEY`.
3. Запустить dry-run на коротком диапазоне.
4. Запустить обработку одного ролика с `--limit 1`.
5. Повторить команду и проверить пропуск уже обработанного ролика.
